### PR TITLE
Task 3. 

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -248,6 +248,12 @@ impl HTMLImageElementMethods for HTMLImageElement {
         image.is_some()
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-img-currentsrc
+    fn CurrentSrc(&self) -> String {
+        let image = self.image.borrow();
+        image.currentRequest.CurrentUrl()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-img-name
     make_getter!(Name);
 

--- a/components/script/dom/webidls/HTMLImageElement.webidl
+++ b/components/script/dom/webidls/HTMLImageElement.webidl
@@ -17,6 +17,7 @@ interface HTMLImageElement : HTMLElement {
   readonly attribute unsigned long naturalWidth;
   readonly attribute unsigned long naturalHeight;
   readonly attribute boolean complete;
+  readonly attribute DOMString currentSrc;
 
   // also has obsolete members
 };


### PR DESCRIPTION
Added the readonly <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element:dom-img-currentsrc">currentSrc attribute</a> to HTMLImageElement.webidl and
implemented the <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-currentsrc">CurrentSrc getter in HTMLImageElement.rs</a>
